### PR TITLE
Add the 'transfers' command to bigset-admin

### DIFF
--- a/rel/files/bigset-admin
+++ b/rel/files/bigset-admin
@@ -215,6 +215,24 @@ case "$1" in
         $NODETOOL rpc bigset_console ringready $@
         ;;
 
+     transfers)
+        if [ $# -ne 1 ]; then
+            echo "Usage: $SCRIPT transfers"
+            exit 1
+        fi
+        shift
+
+        # Make sure the local node IS running
+        RES=`$NODETOOL ping`
+        if [ "$RES" != "pong" ]; then
+            echo "Node is not running!"
+            exit 1
+        fi
+        shift
+
+        $NODETOOL rpc riak_core_console transfers "$@"
+        ;;
+
     member[_-]status)
         if [ $# -ne 1 ]; then
             echo "Usage: $SCRIPT $1"
@@ -287,7 +305,7 @@ case "$1" in
         cluster_admin "$@"
         ;;
     *)
-        echo "Usage: $SCRIPT { cluster | down | ringready | member-status | "
+        echo "Usage: $SCRIPT { cluster | down | transfers | ringready | member-status | "
         echo "                    ring-status | services | wait-for-service "
         exit 1
         ;;


### PR DESCRIPTION
It's easier to pragmatically test that a node is converged and ready
to use if you use `transfers` vs. the human readable table in
`bigset-admin member-status`. Added for perf team's scripted setup.
